### PR TITLE
Implement a blacklist for `--pty`

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,6 +14,12 @@ import (
 // Version is the current value injected at build time.
 var Version string = "HEAD"
 
+// blocklist contains the list of programs not working well with an allocated pty.
+var blocklist = map[string]bool {
+	"xdg-open": true,
+	"gio": true,
+}
+
 // Command line options
 var flagNoPty = flag.Bool("no-pty", false, "Do not allocate a pseudo-terminal for the host process")
 var flagVersion = flag.Bool("version", false, "Show this program's version")
@@ -166,7 +172,8 @@ func main() {
 		command = append([]string{basename}, os.Args[1:]...)
 	}
 
-	allocatePty := !*flagNoPty
+	// Lookup if this is a blacklisted program, where we won't enable pty.
+	allocatePty := (!*flagNoPty && !blocklist[command[0]])
 
 	envsToPassthrough := strings.Split(*flagEnvironmentVariables, ",")
 

--- a/main.go
+++ b/main.go
@@ -15,12 +15,13 @@ import (
 var Version string = "HEAD"
 
 // blocklist contains the list of programs not working well with an allocated pty.
-var blocklist = map[string]bool {
+var blocklist = map[string]bool{
 	"xdg-open": true,
-	"gio": true,
+	"gio":      true,
 }
 
 // Command line options
+var flagPty = flag.Bool("pty", false, "Force allocate a pseudo-terminal for the host process")
 var flagNoPty = flag.Bool("no-pty", false, "Do not allocate a pseudo-terminal for the host process")
 var flagVersion = flag.Bool("version", false, "Show this program's version")
 var flagEnvironmentVariables = flag.String("env", "TERM", "Comma separated list of environment variables to pass to the host process.")
@@ -173,7 +174,12 @@ func main() {
 	}
 
 	// Lookup if this is a blacklisted program, where we won't enable pty.
-	allocatePty := (!*flagNoPty && !blocklist[command[0]])
+	allocatePty := !blocklist[command[0]]
+	if *flagPty {
+		allocatePty = true
+	} else if *flagNoPty {
+		allocatePty = false
+	}
 
 	envsToPassthrough := strings.Split(*flagEnvironmentVariables, ",")
 


### PR DESCRIPTION
This is to work on #12

This implements a very simple lookup table, that disables pty when a matching entry is found.

Fixes #12

Signed-off-by: Luca Di Maio <luca.dimaio1@gmail.com>